### PR TITLE
fix build error for native building

### DIFF
--- a/include/float32_array.h
+++ b/include/float32_array.h
@@ -13,6 +13,16 @@ public:
 
     HTML5_PROPERTY(Float32Array, unsigned long, length);
 
+    class doubleWrapType {
+    public:
+        emscripten::val v;
+        size_t index;
+
+        doubleWrapType(emscripten::val v, size_t index);
+        ~doubleWrapType();
+        void operator=(double value);
+    };
+
     Float32Array(emscripten::val v);
     virtual ~Float32Array();
     static Float32Array *create(emscripten::val v);
@@ -26,7 +36,7 @@ public:
     void set(Array *array, unsigned long offset = 0);
     Float32Array *subarray(long start, long end);
     double operator[](std::size_t index) const;
-    double& operator[](std::size_t index);
+    doubleWrapType operator[](std::size_t index);
 
 private:
     std::vector<double> _rawdata;

--- a/include/float64_array.h
+++ b/include/float64_array.h
@@ -13,6 +13,16 @@ public:
 
     HTML5_PROPERTY(Float64Array, unsigned long, length);
 
+    class doubleWrapType {
+    public:
+        emscripten::val v;
+        size_t index;
+
+        doubleWrapType(emscripten::val v, size_t index);
+        ~doubleWrapType();
+        void operator=(double value);
+    };
+
     Float64Array(emscripten::val v);
     virtual ~Float64Array();
     static Float64Array *create(emscripten::val v);
@@ -26,7 +36,7 @@ public:
     void set(Array *array, unsigned long offset = 0);
     Float64Array *subarray(long start, long end);
     double operator[](std::size_t index) const;
-    double& operator[](std::size_t index);
+    doubleWrapType operator[](std::size_t index);
 
 private:
     std::vector<double> _rawdata;

--- a/include/libhtml5.h
+++ b/include/libhtml5.h
@@ -125,6 +125,9 @@ namespace emscripten {
         void set(std::string name, double value) {};
         void set(std::string name, std::string value) {};
         void set(std::string name, val value) {};
+        void set(size_t index, double value) {};
+        void set(size_t index, std::string value) {};
+        void set(size_t index, val value) {};
     };
 
 };

--- a/include/uint8_clamped_array.h
+++ b/include/uint8_clamped_array.h
@@ -11,6 +11,16 @@ public:
 
     HTML5_PROPERTY(Uint8ClampedArray, unsigned long, length);
 
+    class uint8WrapType {
+    public:
+        emscripten::val v;
+        size_t index;
+
+        uint8WrapType(emscripten::val v, size_t index);
+        ~uint8WrapType();
+        void operator=(uint8_t value);
+    };
+
     Uint8ClampedArray(emscripten::val v);
     virtual ~Uint8ClampedArray();
     static Uint8ClampedArray *create(emscripten::val v);
@@ -21,7 +31,7 @@ public:
     static Uint8ClampedArray *create(ArrayBuffer *buffer, unsigned long byteOffset);
     static Uint8ClampedArray *create(ArrayBuffer *buffer, unsigned long byteOffset, unsigned long length);
     uint8_t operator[](std::size_t index) const;
-    uint8_t& operator[](std::size_t index);
+    uint8WrapType operator[](std::size_t index);
     
 private:
     std::vector<uint8_t> _rawdata;

--- a/src/float32_array.cc
+++ b/src/float32_array.cc
@@ -76,13 +76,26 @@ double Float32Array::operator[](std::size_t index) const
 #endif
 }
 
-double& Float32Array::operator[](std::size_t index)
+Float32Array::doubleWrapType::doubleWrapType(emscripten::val v, size_t index) :
+    v(v),
+    index(index)
 {
-#if ENABLE_EMSCRIPTEN
-    return this->v[index].as<double>();
-#else
-    return this->_rawdata[index];
-#endif
+
+}
+
+Float32Array::doubleWrapType::~doubleWrapType()
+{
+
+}
+
+void Float32Array::doubleWrapType::operator=(double value)
+{
+    this->v.set(this->index, value);
+}
+
+Float32Array::doubleWrapType Float32Array::operator[](std::size_t index)
+{
+    return Float32Array::doubleWrapType(this->v, index);
 }
 
 HTML5_PROPERTY_IMPL(Float32Array, unsigned long, length);

--- a/src/float64_array.cc
+++ b/src/float64_array.cc
@@ -76,13 +76,26 @@ double Float64Array::operator[](std::size_t index) const
 #endif
 }
 
-double& Float64Array::operator[](std::size_t index)
+Float64Array::doubleWrapType::doubleWrapType(emscripten::val v, size_t index) :
+    v(v),
+    index(index)
 {
-#if ENABLE_EMSCRIPTEN
-    return this->v[index].as<double>();
-#else
-    return this->_rawdata[index];
-#endif
+
+}
+
+Float64Array::doubleWrapType::~doubleWrapType()
+{
+
+}
+
+void Float64Array::doubleWrapType::operator=(double value)
+{
+    this->v.set(this->index, value);
+}
+
+Float64Array::doubleWrapType Float64Array::operator[](std::size_t index)
+{
+    return Float64Array::doubleWrapType(this->v, index);
 }
 
 HTML5_PROPERTY_IMPL(Float64Array, unsigned long, length);

--- a/src/uint8_clamped_array.cc
+++ b/src/uint8_clamped_array.cc
@@ -60,13 +60,26 @@ uint8_t Uint8ClampedArray::operator[](std::size_t index) const
 #endif
 }
 
-uint8_t& Uint8ClampedArray::operator[](std::size_t index)
+Uint8ClampedArray::uint8WrapType::uint8WrapType(emscripten::val v, size_t index) :
+    v(v),
+    index(index)
 {
-#if ENABLE_EMSCRIPTEN
-    return this->v[index].as<uint8_t>();
-#else
-    return this->_rawdata[index];
-#endif
+
+}
+
+Uint8ClampedArray::uint8WrapType::~uint8WrapType()
+{
+
+}
+
+void Uint8ClampedArray::uint8WrapType::operator=(uint8_t value)
+{
+    this->v.set(this->index, value);
+}
+
+Uint8ClampedArray::uint8WrapType Uint8ClampedArray::operator[](std::size_t index)
+{
+    return Uint8ClampedArray::uint8WrapType(this->v, index);
 }
 
 HTML5_PROPERTY_IMPL(Uint8ClampedArray, unsigned long, length);


### PR DESCRIPTION
must hook `array[idx] = value` and set `value` to `emscripten::val` ( `Float32Array` or `Float64Array` and so on) . 
But, `T &operator[](size_t index)` technique cannot use in this case, because `emscripten::val::as` cannot return reference to value. So, I resolved it by using WrapType for `double` or `uint8_t` .

`WrapType operator[](size_t index)` and `WrapType` implements `void operator=(T value);` .
Therefore, call `array[idx] = value` and return `WrapType` for `value` also called `void operator=(T value);` :)