### PR TITLE
Fix interface for exported functions

### DIFF
--- a/include/export.h
+++ b/include/export.h
@@ -57,9 +57,9 @@ extern WindowProxy *open(std::string url, std::string target, std::string featur
 extern void postMessage(void *message, std::string targetOrigin, std::vector<Transferable *> transfer);
 extern void print();
 extern std::string prompt(std::string message, std::string _default);
-extern long requestAnimationFrame(std::function<void(double)> *callback);
-extern long setInterval(std::function<void(void)> *handler, long timeout);
-extern long setTimeout(std::function<void(void)> handler, long timeout);
+extern long requestAnimationFrame(const std::function<void(double)> &callback);
+extern long setInterval(const std::function<void(void)> &handler, long timeout);
+extern long setTimeout(const std::function<void(void)> &handler, long timeout);
 extern void stop();
 
 NAMESPACE_HTML5_END;

--- a/include/window.h
+++ b/include/window.h
@@ -163,17 +163,17 @@ public:
     void postMessage(void *message, std::string targetOrigin, std::vector<Transferable *> transfer);
     void print();
     std::string prompt(std::string message, std::string _default);
-    long requestAnimationFrame(std::function<void(double)> *callback);
-    long setInterval(std::function<void(void)> *handler, long timeout);
-    long setTimeout(std::function<void(void)> handler, long timeout);
+    long requestAnimationFrame(const std::function<void(double)> &callback);
+    long setInterval(const std::function<void(void)> &handler, long timeout);
+    long setTimeout(const std::function<void(void)> &handler, long timeout);
     void stop();
 
     void requestAnimationFrameCallback(double time);
     void setIntervalCallback();
     void setTimeoutCallback();
 private:
-    std::function<void(double)> *_requestAnimationFrameFn;
-    std::function<void(void)> *_setIntervalFn;
+    std::function<void(double)> _requestAnimationFrameFn;
+    std::function<void(void)> _setIntervalFn;
     std::function<void(void)> _setTimeoutFn;
 };
 

--- a/src/export.cc
+++ b/src/export.cc
@@ -150,17 +150,17 @@ std::string prompt(std::string message, std::string _default)
     return window->prompt(message, _default);
 }
 
-long requestAnimationFrame(std::function<void(double)> *callback)
+long requestAnimationFrame(const std::function<void(double)> &callback)
 {
     return window->requestAnimationFrame(callback);
 }
 
-long setInterval(std::function<void(void)> *handler, long timeout)
+long setInterval(const std::function<void(void)> &handler, long timeout)
 {
     return window->setInterval(handler, timeout);
 }
 
-long setTimeout(std::function<void(void)> handler, long timeout)
+long setTimeout(const std::function<void(void)> &handler, long timeout)
 {
     return window->setTimeout(handler, timeout);
 }

--- a/src/window.cc
+++ b/src/window.cc
@@ -173,7 +173,7 @@ std::string Window::prompt(std::string message, std::string _default)
     return HTML5_CALLs(this->v, prompt, message, _default);
 }
 
-long Window::requestAnimationFrame(std::function<void(double)> *callback)
+long Window::requestAnimationFrame(const std::function<void(double)> &callback)
 {
     this->_requestAnimationFrameFn = callback;
     return EM_ASM_INT({
@@ -186,12 +186,12 @@ long Window::requestAnimationFrame(std::function<void(double)> *callback)
 
 void Window::requestAnimationFrameCallback(double time)
 {
-    if (!this->_requestAnimationFrameFn) return;
+    if (this->_requestAnimationFrameFn == nullptr) return;
 
-    (*this->_requestAnimationFrameFn)(time);
+    this->_requestAnimationFrameFn(time);
 }
 
-long Window::setInterval(std::function<void(void)> *handler, long timeout)
+long Window::setInterval(const std::function<void(void)> &handler, long timeout)
 {
     this->_setIntervalFn = handler;
     return EM_ASM_INT({
@@ -204,12 +204,12 @@ long Window::setInterval(std::function<void(void)> *handler, long timeout)
 
 void Window::setIntervalCallback()
 {
-    if (!this->_setIntervalFn) return;
+    if (this->_setIntervalFn == nullptr) return;
 
-    (*this->_setIntervalFn)();
+    this->_setIntervalFn();
 }
 
-long Window::setTimeout(std::function<void(void)> handler, long timeout)
+long Window::setTimeout(const std::function<void(void)> &handler, long timeout)
 {
     this->_setTimeoutFn = handler;
     return EM_ASM_INT({
@@ -222,7 +222,7 @@ long Window::setTimeout(std::function<void(void)> handler, long timeout)
 
 void Window::setTimeoutCallback()
 {
-    if (!this->_setTimeoutFn) return;
+    if (this->_setTimeoutFn == nullptr) return;
 
     this->_setTimeoutFn();
 }


### PR DESCRIPTION
Pass reference value instead of pointer value in `std::function` .