### PR TITLE
Implements Regexp.exec() Function

### DIFF
--- a/include/html5_regexp.h
+++ b/include/html5_regexp.h
@@ -25,6 +25,7 @@ public:
     static regexp *create(std::string pattern);
     static regexp *create(std::string pattern, std::string flags);
     bool test(std::string s);
+    array *exec(std::string s);
 };
 
 NAMESPACE_HTML5_END;

--- a/include/html5_regexp.h
+++ b/include/html5_regexp.h
@@ -25,7 +25,7 @@ public:
     static regexp *create(std::string pattern);
     static regexp *create(std::string pattern, std::string flags);
     bool test(std::string s);
-    std::vector<html5::string> exec(std::string s);
+    std::vector<html5::string> exec(const std::string &s);
 };
 
 NAMESPACE_HTML5_END;

--- a/include/html5_regexp.h
+++ b/include/html5_regexp.h
@@ -25,7 +25,7 @@ public:
     static regexp *create(std::string pattern);
     static regexp *create(std::string pattern, std::string flags);
     bool test(std::string s);
-    array *exec(std::string s);
+    std::vector<html5::string> exec(std::string s);
 };
 
 NAMESPACE_HTML5_END;

--- a/src/regexp.cc
+++ b/src/regexp.cc
@@ -67,6 +67,11 @@ bool regexp::test(std::string s)
     return HTML5_CALLb(this->v, test, s);
 }
 
+array *regexp::exec(std::string s)
+{
+    return array::create(HTML5_CALLv(this->v, exec, s));
+}
+
 HTML5_PROPERTY_IMPL(regexp, bool, global);
 HTML5_PROPERTY_IMPL(regexp, bool, ignoreCase);
 HTML5_PROPERTY_IMPL(regexp, int, lastIndex);

--- a/src/regexp.cc
+++ b/src/regexp.cc
@@ -67,7 +67,7 @@ bool regexp::test(std::string s)
     return HTML5_CALLb(this->v, test, s);
 }
 
-std::vector<html5::string> regexp::exec(std::string s)
+std::vector<html5::string> regexp::exec(const std::string &s)
 {
     auto v = HTML5_CALLv(this->v, exec, s);
     if (v.isNull()) {

--- a/src/regexp.cc
+++ b/src/regexp.cc
@@ -67,9 +67,13 @@ bool regexp::test(std::string s)
     return HTML5_CALLb(this->v, test, s);
 }
 
-array *regexp::exec(std::string s)
+std::vector<html5::string> regexp::exec(std::string s)
 {
-    return array::create(HTML5_CALLv(this->v, exec, s));
+    auto v = HTML5_CALLv(this->v, exec, s);
+    if (v.isNull()) {
+        return std::vector<html5::string>();
+    }
+    return toArray<html5::string>(v);
 }
 
 HTML5_PROPERTY_IMPL(regexp, bool, global);


### PR DESCRIPTION
implements `regexp.exec()` function returned `*html5::array` ([]string or null)